### PR TITLE
make it more like how autotools does it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,17 @@ C_OBJS := $(C_SRC:%.c=%.o)
 PREFIX ?= /usr/local
 
 # Commands
-CC := $(CROSS_COMPILE)cc
+HASGCC := $(shell command -v $(CROSS_COMPILE)gcc 2> /dev/null)
+HASCLANG := $(shell command -v $(CROSS_COMPILE)clang 2> /dev/null)
+ifdef HASGCC
+	CC := $(CROSS_COMPILE)gcc
+else
+	ifdef HASCLANG
+		CC := $(CROSS_COMPILE)clang
+	else
+		CC := $(CROSS_COMPILE)cc
+	endif
+endif
 CP := cp -f
 RM := rm -rf
 LN := ln -f

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ C_OBJS := $(C_SRC:%.c=%.o)
 PREFIX ?= /usr/local
 
 # Commands
-CC := cc
+CC := $(CROSS_COMPILE)cc
 CP := cp -f
 RM := rm -rf
 LN := ln -f
-STRIP := strip
+STRIP := $(CROSS_COMPILE)strip
 
 all: vi ex
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ C_HEAD := $(C_SRC:%.c=%.h) kmap.h helper.h
 C_OBJS := $(C_SRC:%.c=%.o)
 
 # Install targets
-DESTDIR ?= /usr/local/bin
+PREFIX ?= /usr/local
 
 # Commands
 CC := gcc
@@ -36,14 +36,14 @@ ex: vi
 	$(LN) vi ex
 
 install : | vi ex
-	mkdir -p $(DESTDIR)
-	$(CP) vi $(DESTDIR)/
-	$(STRIP) $(DESTDIR)/vi
-	$(LN) $(DESTDIR)/vi $(DESTDIR)/ex
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	$(CP) vi $(DESTDIR)$(PREFIX)/bin/
+	$(STRIP) $(DESTDIR)$(PREFIX)/bin/vi
+	$(LN) $(DESTDIR)$(PREFIX)/bin/vi $(DESTDIR)$(PREFIX)/bin/ex
 
 uninstall :
-	$(RM) $(DESTDIR)/ex
-	$(RM) $(DESTDIR)/vi
+	$(RM) $(DESTDIR)$(PREFIX)/bin/ex
+	$(RM) $(DESTDIR)$(PREFIX)/bin/vi
 
 clean : 
 	$(RM) vi

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,12 @@ else
 		CC := $(CROSS_COMPILE)cc
 	endif
 endif
-CP := cp -f
 RM := rm -rf
-LN := ln -f
+ifeq $(shell uname -o),Android)
+	CP := cp -f
+else
+	CP := cp -lf
+endif
 STRIP := $(CROSS_COMPILE)strip
 
 all: vi ex
@@ -43,13 +46,13 @@ vi: $(C_OBJS)
 	$(CC) $(C_OBJS) $(CFLAGS) -o $@
 
 ex: vi
-	$(LN) vi ex
+	$(CP) vi ex
 
 install : | vi ex
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	$(CP) vi $(DESTDIR)$(PREFIX)/bin/
 	$(STRIP) $(DESTDIR)$(PREFIX)/bin/vi
-	$(LN) $(DESTDIR)$(PREFIX)/bin/vi $(DESTDIR)$(PREFIX)/bin/ex
+	$(CP) $(DESTDIR)$(PREFIX)/bin/vi $(DESTDIR)$(PREFIX)/bin/ex
 
 uninstall :
 	$(RM) $(DESTDIR)$(PREFIX)/bin/ex

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ C_OBJS := $(C_SRC:%.c=%.o)
 PREFIX ?= /usr/local
 
 # Commands
-CC := gcc
+CC := cc
 CP := cp -f
 RM := rm -rf
 LN := ln -f


### PR DESCRIPTION
there are now 2 variables that affect the location where `make install` puts everything, there is PREFIX and DESTDIR, prefix works mostly how DESTDIR worked before, and DESTDIR is now an optional path to prepend to the other paths, this is mostly used for packaging